### PR TITLE
Do not run the travis ci tests that use source code with Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
 
 script:
   - jdk_switcher use oraclejdk8
-  - sbt testOnly -- -l edu.colorado.plv.fixr.tests.TestParseSources
+  - sbt "testOnly -- -l edu.colorado.plv.fixr.tests.TestParseSources"
   - jdk_switcher use openjdk7
   - sbt -java-home $JAVA_HOME test


### PR DESCRIPTION
The soot parser does not work with Java 8, so we cannot run the
regression tests using it.

The new travis CI configuration run all the tests with Java 7 and only
the tests that do not use source code with Java 8.