### PR TITLE
Enable multidex and fix soot null pointer exception

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,5 +47,6 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "scalatags" % "0.6.7",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "org.ow2.asm" % "asm-debug-all" % "5.1",
-  "com.github.javaparser" % "javaparser-core" % "3.14.16"
+  "com.github.javaparser" % "javaparser-core" % "3.14.16",
+  "ca.mcgill.sable" % "soot" % "3.3.0"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,5 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %% "scalatags" % "0.6.7",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "org.ow2.asm" % "asm-debug-all" % "5.1",
-  "com.github.javaparser" % "javaparser-core" % "3.14.16",
-  "ca.mcgill.sable" % "soot" % "3.3.0"
+  "com.github.javaparser" % "javaparser-core" % "3.14.16"
 )

--- a/lib/sootclasses.md
+++ b/lib/sootclasses.md
@@ -1,0 +1,5 @@
+Note: the soot dependency was built from https://github.com/cuplv/soot/tree/npe_issue_618
+Compile with the following command:
+```
+mvn clean compile assembly:single
+```

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
 
 addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")

--- a/src/main/java/edu/colorado/plv/fixr/SootHelper.java
+++ b/src/main/java/edu/colorado/plv/fixr/SootHelper.java
@@ -145,6 +145,7 @@ public class SootHelper {
       Options.v().set_allow_phantom_refs(true);
       Options.v().set_src_prec(Options.src_prec_apk);
       Options.v().set_android_jars(androidJars);
+      Options.v().set_process_multiple_dex(true);
 
       setBytecodeOptions();
     }

--- a/src/main/java/edu/colorado/plv/fixr/slicing/APISlicer.java
+++ b/src/main/java/edu/colorado/plv/fixr/slicing/APISlicer.java
@@ -221,7 +221,7 @@ public class APISlicer {
   private Set<Unit> getSeeds(SlicingCriterion sc)
   {
     Set<Unit> seeds = new HashSet<Unit>();
-    for (Object node : pdg.getNodes()) {
+    for (Object node : pdg){// TODO: test change, used to be: pdg.getNodes()) {
       if (node instanceof PDGNode) {
         Object innerNode = ((PDGNode) node).getNode();
         if (innerNode instanceof Block) {

--- a/src/test/scala/edu/colorado/plv/fixr/tests/regression/TestBug058.scala
+++ b/src/test/scala/edu/colorado/plv/fixr/tests/regression/TestBug058.scala
@@ -20,10 +20,7 @@ class TestBug058 extends FunSuite with BeforeAndAfter {
     options.methodName = "bug_058"
     options.configCode = SootHelper.READ_FROM_BYTECODE    
     options.sliceFilter = List("android")
-    val androidJarPath = getClass.getResource("/libs/android-17.jar").getPath
-    val javasources = getClass.getResource("/javasources").getPath
-//    options.sootClassPath = "./src/test/resources/libs/android-17.jar:./src/test/resources/javasources"
-    options.sootClassPath = s"${androidJarPath}:${javasources}"
+    options.sootClassPath = "./src/test/resources/libs/android-17.jar:./src/test/resources/javasources"
     options.outputDir = null
     options.provenanceDir = null
     options.processDir = null
@@ -32,9 +29,7 @@ class TestBug058 extends FunSuite with BeforeAndAfter {
     options.storeAcdfg = true
 
     var extractor : Extractor = new MethodExtractor(options);
-//    Thread.sleep(10000)
     extractor.extract()
-    Thread.sleep(10000)
 
     val transformer = extractor.getTransformer
     transformer.acdfgListBuffer.foreach( (x : edu.colorado.plv.fixr.abstraction.Acdfg)  => {

--- a/src/test/scala/edu/colorado/plv/fixr/tests/regression/TestBug058.scala
+++ b/src/test/scala/edu/colorado/plv/fixr/tests/regression/TestBug058.scala
@@ -20,7 +20,10 @@ class TestBug058 extends FunSuite with BeforeAndAfter {
     options.methodName = "bug_058"
     options.configCode = SootHelper.READ_FROM_BYTECODE    
     options.sliceFilter = List("android")
-    options.sootClassPath = "./src/test/resources/libs/android-17.jar:./src/test/resources/javasources"
+    val androidJarPath = getClass.getResource("/libs/android-17.jar").getPath
+    val javasources = getClass.getResource("/javasources").getPath
+//    options.sootClassPath = "./src/test/resources/libs/android-17.jar:./src/test/resources/javasources"
+    options.sootClassPath = s"${androidJarPath}:${javasources}"
     options.outputDir = null
     options.provenanceDir = null
     options.processDir = null
@@ -29,7 +32,9 @@ class TestBug058 extends FunSuite with BeforeAndAfter {
     options.storeAcdfg = true
 
     var extractor : Extractor = new MethodExtractor(options);
+//    Thread.sleep(10000)
     extractor.extract()
+    Thread.sleep(10000)
 
     val transformer = extractor.getTransformer
     transformer.acdfgListBuffer.foreach( (x : edu.colorado.plv.fixr.abstraction.Acdfg)  => {

--- a/src/test/scala/edu/colorado/plv/fixr/tests/slicing/TestSlicing.scala
+++ b/src/test/scala/edu/colorado/plv/fixr/tests/slicing/TestSlicing.scala
@@ -43,12 +43,19 @@ abstract class TestSlicing(classPath : String, testClassName : String,
 
     val bodyToSlice : Body = testClass.getMethodByName(methodName).retrieveActiveBody();
     val expectedRes : Body = resClass.getMethodByName(APISlicer.getSlicedMethodName(methodName)).retrieveActiveBody();
-
+    println("----body to slice----")
+    println(bodyToSlice)
     val slicer : APISlicer = new APISlicer(bodyToSlice);
     val slicedBody : Body = slicer.slice(new MethodPackageSeed(getPackages()));
-
+    println("----body to slice after slice----")
+    println(bodyToSlice)
     assert(null != slicedBody) /* at least one seed in the test*/
     /* obtained and expected results must be the same */
+
+    println("----expected-----")
+    println(expectedRes)
+    println("\n----actual----")
+    println(slicedBody)
     assert(SootHelper.compareBodies(expectedRes, slicedBody));
   }
 }

--- a/src/test/scala/edu/colorado/plv/fixr/tests/slicing/TestSlicing.scala
+++ b/src/test/scala/edu/colorado/plv/fixr/tests/slicing/TestSlicing.scala
@@ -43,19 +43,12 @@ abstract class TestSlicing(classPath : String, testClassName : String,
 
     val bodyToSlice : Body = testClass.getMethodByName(methodName).retrieveActiveBody();
     val expectedRes : Body = resClass.getMethodByName(APISlicer.getSlicedMethodName(methodName)).retrieveActiveBody();
-    println("----body to slice----")
-    println(bodyToSlice)
+
     val slicer : APISlicer = new APISlicer(bodyToSlice);
     val slicedBody : Body = slicer.slice(new MethodPackageSeed(getPackages()));
-    println("----body to slice after slice----")
-    println(bodyToSlice)
+
     assert(null != slicedBody) /* at least one seed in the test*/
     /* obtained and expected results must be the same */
-
-    println("----expected-----")
-    println(expectedRes)
-    println("\n----actual----")
-    println(slicedBody)
     assert(SootHelper.compareBodies(expectedRes, slicedBody));
   }
 }


### PR DESCRIPTION
Note: this is paired with a change to Soot that I will issue a pull request for in the near future: https://github.com/cuplv/soot/tree/npe_issue_618

This pull request:
1) updates to a newer version of soot
2) adds a jar of soot fixed from the branch shown above
3) adds the multi dex flag for reading apks
4) updates the protocol buffer sbt plugin to avoid a crash